### PR TITLE
Fix strictures perlcritic error

### DIFF
--- a/lib/Algorithm/TokenBucket.pm
+++ b/lib/Algorithm/TokenBucket.pm
@@ -2,10 +2,10 @@ package Algorithm::TokenBucket;
 
 use 5.006;
 
-our $VERSION = 0.37;
-
 use warnings;
 use strict;
+
+our $VERSION = 0.37;
 
 use Time::HiRes qw/time/;
 


### PR DESCRIPTION
`perlcritic` noticed that there was code before strictures were set.  This
merely required the `VERSION` to be moved after the `warnings` and `strict`
pragmas.
