### PR TITLE
Use direct object syntax for `new()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Algorithm::TokenBucket - Token bucket rate limiting algorithm
 
        # configure a bucket to limit a stream up to 100 items per hour
        # with bursts of 5 items max
-       my $bucket = new Algorithm::TokenBucket 100 / 3600, 5;
+       my $bucket = Algorithm::TokenBucket->new(100 / 3600, 5);
 
        # wait until we are allowed to process 3 items
        until ($bucket->conform(3)) {
@@ -39,8 +39,8 @@ Algorithm::TokenBucket - Token bucket rate limiting algorithm
        # we're likely to have processed 200 items (and hogged CPU)
 
        Storable::store $bucket, 'bucket.stored';
-       my $bucket1 = new Algorithm::TokenBucket
-               @{Storable::retrieve('bucket.stored')};
+       my $bucket1 =
+         Algorithm::TokenBucket->new( @{ Storable::retrieve('bucket.stored') } );
 
 # DESCRIPTION
 
@@ -112,8 +112,8 @@ taken from [http://linux-ip.net/gl/tcng/node62.html](http://linux-ip.net/gl/tcng
 Imagine a rate limiter for a mail sending application. We would like to
 allow 2 mails per minute but no more than 20 mails per hour.
 
-    my $rl1 = new Algorithm::TokenBucket 2/60, 1;
-    my $rl2 = new Algorithm::TokenBucket 20/3600, 10;
+    my $rl1 = Algorithm::TokenBucket->new(2/60, 1);
+    my $rl2 = Algorithm::TokenBucket->new(20/3600, 10);
         # "bursts" of 10 to ease the lag but $rl1 enforces
         # 2 per minute, so it won't flood
 
@@ -129,7 +129,7 @@ allow 2 mails per minute but no more than 20 mails per hour.
 Now, let's fix the CPU-hogging example from ["SYNOPSIS"](#synopsis) using
 ["until()"](#until) method.
 
-    my $bucket = new Algorithm::TokenBucket 100 / 3600, 5;
+    my $bucket = Algorithm::TokenBucket->new(100 / 3600, 5);
     my $time = Time::HiRes::time;
     while (Time::HiRes::time - $time < 7200) {  # two hours
         # be bursty

--- a/lib/Algorithm/TokenBucket.pm
+++ b/lib/Algorithm/TokenBucket.pm
@@ -19,7 +19,7 @@ Algorithm::TokenBucket - Token bucket rate limiting algorithm
 
     # configure a bucket to limit a stream up to 100 items per hour
     # with bursts of 5 items max
-    my $bucket = new Algorithm::TokenBucket 100 / 3600, 5;
+    my $bucket = Algorithm::TokenBucket->new(100 / 3600, 5);
 
     # wait until we are allowed to process 3 items
     until ($bucket->conform(3)) {
@@ -50,8 +50,8 @@ Algorithm::TokenBucket - Token bucket rate limiting algorithm
     # we're likely to have processed 200 items (and hogged CPU)
 
     Storable::store $bucket, 'bucket.stored';
-    my $bucket1 = new Algorithm::TokenBucket
-            @{Storable::retrieve('bucket.stored')};
+    my $bucket1 =
+      Algorithm::TokenBucket->new( @{ Storable::retrieve('bucket.stored') } );
 
 =head1 DESCRIPTION
 
@@ -229,8 +229,8 @@ __END__
 Imagine a rate limiter for a mail sending application. We would like to
 allow 2 mails per minute but no more than 20 mails per hour.
 
-    my $rl1 = new Algorithm::TokenBucket 2/60, 1;
-    my $rl2 = new Algorithm::TokenBucket 20/3600, 10;
+    my $rl1 = Algorithm::TokenBucket->new(2/60, 1);
+    my $rl2 = Algorithm::TokenBucket->new(20/3600, 10);
         # "bursts" of 10 to ease the lag but $rl1 enforces
         # 2 per minute, so it won't flood
 
@@ -246,7 +246,7 @@ allow 2 mails per minute but no more than 20 mails per hour.
 Now, let's fix the CPU-hogging example from L</SYNOPSIS> using
 L</until()> method.
 
-    my $bucket = new Algorithm::TokenBucket 100 / 3600, 5;
+    my $bucket = Algorithm::TokenBucket->new(100 / 3600, 5);
     my $time = Time::HiRes::time;
     while (Time::HiRes::time - $time < 7200) {  # two hours
         # be bursty

--- a/t/basic.t
+++ b/t/basic.t
@@ -8,7 +8,7 @@ use Time::HiRes qw/sleep time/;
 
 BEGIN { use_ok('Algorithm::TokenBucket'); }
 
-my $bucket = new Algorithm::TokenBucket 25/1, 4;
+my $bucket = Algorithm::TokenBucket->new(25/1, 4);
 isa_ok($bucket, 'Algorithm::TokenBucket');
 is($bucket->{info_rate}, 25, 'info_rate init');
 is($bucket->{burst_size}, 4, 'burst_size init');
@@ -54,7 +54,7 @@ while (time - $time < 2) {
 }
 cmp_ok($traffic, '>=', 0, '50 or less in 2 seconds');
 
-$bucket = new Algorithm::TokenBucket 25/1, 4; # start afresh (point C)
+$bucket = Algorithm::TokenBucket->new(25/1, 4); # start afresh (point C)
 
 my @state = $bucket->state;
 is($state[0], 25, 'state[0]');
@@ -62,7 +62,7 @@ is($state[1], 4, 'state[1]');
 cmp_ok($state[2], '<', 0.01, 'state[2]');
 cmp_ok(abs($state[3] - time), '<', 0.1, 'state[3]');
 
-my $bucket1 = new Algorithm::TokenBucket @state;
+my $bucket1 = Algorithm::TokenBucket->new(@state);
 isa_ok($bucket1, 'Algorithm::TokenBucket');
 ok(!$bucket1->conform(2), 'restored bucket is almost empty'); # point D
 # if it took us long (>1/25 sec) from point C up to point D, conform(1) could be true


### PR DESCRIPTION
As mentioned in the [Perl method invocation documentation](http://perldoc.perl.org/perlobj.html#Method-Invocation), one is advised to use the direct object syntax for calls to `new()`.  These changes update the documentation and tests to use the recommended syntax.
